### PR TITLE
OGP画像のwidth/heightを追加

### DIFF
--- a/site/src/layouts/index.tsx
+++ b/site/src/layouts/index.tsx
@@ -34,7 +34,6 @@ const IndexLayout: React.FC = ({ children }) => (
     query={graphql`
       query IndexLayoutQuery {
         site {
-          host
           siteMetadata {
             title
             description

--- a/site/src/layouts/index.tsx
+++ b/site/src/layouts/index.tsx
@@ -64,7 +64,9 @@ const IndexLayout: React.FC = ({ children }) => (
             { property: 'og:url', content: data.site.siteMetadata.siteUrl },
             { property: 'og:type', content: data.site.siteMetadata.type },
             { property: 'og:site_name', content: data.site.siteMetadata.siteName },
-            { property: 'og:image', content: data.site.siteMetadata.siteUrl + data.file.childImageSharp.resize.src }
+            { property: 'og:image', content: data.site.siteMetadata.siteUrl + data.file.childImageSharp.resize.src },
+            { property: 'og:image:width', content: '200' },
+            { property: 'og:image:height', content: '200' }
           ]}
         />
         <Header title={data.site.siteMetadata.title} />


### PR DESCRIPTION
#21 に関する追加の修正です。

#74 の追加の修正で、
gatsby.jsのようなページが動的に生成されるような場合、
画像のシェアでうまく表示されず、
`og:image:width` og:image:height` の指定が必要なようでした。

そのために、widthとheightを追加させていただきました。
考慮漏れで申し訳ないです。
