### PR TITLE
fix: format date after validate

### DIFF
--- a/convert_data.py
+++ b/convert_data.py
@@ -54,12 +54,12 @@ if __name__ == "__main__":
     # load csv data
     for key in loaded.keys():
         date = StringUtil.extract_date_from_title(loaded.get(key))
-        ymd = date.strftime('%Y%m%d')
         if (not date):
             print('The system could not retrieve date string from the title "{0}" '
                   .format(
                       loaded.get(key)))
             continue
+        ymd = date.strftime('%Y%m%d')
         processor = Processor(date)  # create processor instance
         print('Create file for the date {0}'.format(date))
         target_dir = RAW_DIR + '/' + key


### PR DESCRIPTION
failed convert data

> https://github.com/codeforjapan/mynumbercard_statistics/runs/995916816?check_suite_focus=true#step:4:2901
```
* saved 1742 lines for all_localgovs.csv
  File "convert_data.py", line 57, in <module>
    ymd = date.strftime('%Y%m%d')
AttributeError: 'bool' object has no attribute 'strftime'
Makefile:9: recipe for target 'convert' failed
make: *** [convert] Error 1
```

8月のデータが「マイナンバーカード交付状況（令和◯年◯月◯日現在）」ではなく「PDF形式」というタイトルになっていることに関連して生じていた模様
https://github.com/codeforjapan/mynumbercard_statistics/runs/995916816?check_suite_focus=true#step:4:2766