### PR TITLE
local registryを用いたdocker imageのキャッシュ

### DIFF
--- a/.github/workflows/gh-page-dev.yml
+++ b/.github/workflows/gh-page-dev.yml
@@ -21,7 +21,35 @@ jobs:
           path: data
           key: ${{ runner.os }}-mynumbercard-dev-${{ hashFiles(format('{0}{1}', github.workspace, '/VERSION')) }}
 
-      - name: Build Image
+      - uses: actions/checkout@v2
+      - id: cache-docker
+        uses: actions/cache@v1
+        with:
+          path: /tmp/docker-registry
+          key: docker-registry-no-buildkit-dev-${{ hashFiles('Dockerfile') }}
+
+      - name: Start local registry
+        run: docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2 && npx wait-on tcp:5000
+
+      - name: Pull docker image from local registry
+        run: docker pull localhost:5000/mynumbercard-app || true
+
+      - name: Build Image when docker image cache not hit
+        run: docker build . -t mynumbercard-app --cache-from=localhost:5000/mynumbercard-app
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+
+      - name: Push Image to local registry when docker image cache not hit
+        run: docker tag mynumbercard-app localhost:5000/mynumbercard-app && docker push localhost:5000/mynumbercard-app || true
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+
+      - name: Tag pulled image to use docker-compose
+        run: docker tag localhost:5000/mynumbercard-app mynumbercard-app
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+
+      - name: Make docker to look override docker-compose.yml only on CI
+        run: mv docker-compose.override.ci.yml docker-compose.override.yml
+
+      - name: Exec download and convert data
         run: |
           make download_and_convert
 

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -22,7 +22,36 @@ jobs:
           path: data
           key: ${{ runner.os }}-mynumbercard-${{ hashFiles(format('{0}{1}', github.workspace, '/VERSION')) }}
           restore-keys: ${{ runner.os }}-mynumbercard-
-      - name: Build Image
+
+      - uses: actions/checkout@v2
+      - id: cache-docker
+        uses: actions/cache@v1
+        with:
+          path: /tmp/docker-registry
+          key: docker-registry-no-buildkit-${{ hashFiles('Dockerfile') }}
+
+      - name: Start local registry
+        run: docker run -d -p 5000:5000 --restart=always --name registry -v /tmp/docker-registry:/var/lib/registry registry:2 && npx wait-on tcp:5000
+
+      - name: Pull docker image from local registry
+        run: docker pull localhost:5000/mynumbercard-app || true
+
+      - name: Build Image when docker image cache not hit
+        run: docker build . -t mynumbercard-app --cache-from=localhost:5000/mynumbercard-app
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+
+      - name: Push Image to local registry when docker image cache not hit
+        run: docker tag mynumbercard-app localhost:5000/mynumbercard-app && docker push localhost:5000/mynumbercard-app || true
+        if: steps.cache-docker.outputs.cache-hit != 'true'
+
+      - name: Tag pulled image to use docker-compose
+        run: docker tag localhost:5000/mynumbercard-app mynumbercard-app
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+
+      - name: Make docker to look override docker-compose.yml only on CI
+        run: mv docker-compose.override.ci.yml docker-compose.override.yml
+
+      - name: Exec download and convert data
         run: |
           make download_and_convert
 

--- a/docker-compose.override.ci.yml
+++ b/docker-compose.override.ci.yml
@@ -1,0 +1,4 @@
+version: '3'
+services:
+  app:
+    image: mynumbercard-app


### PR DESCRIPTION
closes #2

# 対応した課題

* github actions内で毎度docker imageをビルドしており、キャッシュを用いてビルド分の実行時間を短縮させたい。
  * docker imageのビルド時間は2分34秒であった。 
    * 過去に実行したworkflowのBuild Image stepの、image buildの時間から確認した。
      * https://github.com/codeforjapan/mynumbercard_statistics/runs/2778760644?check_suite_focus=true
    * ビルド開始のタイムスタンプ: 23:01:09
    * ビルド終了のタイムスタンプ: 23:03:43
      * 引き算すると2分34秒となる。

# 対応方針

* キャッシュの方法として、以下の記事を参考にlocal registry機能を使うようにした。
  * https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei
    * 2番めに速いlocal registryで実現した。
    * 1番速いのはgithub packagesだがpersonal access tokenを使う必要があり、これは特定のユーザーアカウントにGitHub actionsの実行が依存するため、OSSに適さないと判断した。
      * 管理しているbot用のユーザーアカウントがあるなど、特定のユーザーアカウントに依存しても問題ない場合はGitHub packagesを用いるのが良いと思う。

# 実行結果

* キャッシュにヒットした場合は、37秒になる。
  * https://github.com/ryan5500/mynumbercard_statistics/runs/2793421048?check_suite_focus=true
  * 追加された以下2つのstepの合計時間が37秒だった。
    * Start local registry: 10秒
    * Pull docker image from local registry: 27秒


* Dockerfileが更新されるとキャッシュにヒットしなくなる。この場合は従来よりも時間が長くなる。(4分22秒) 
  * https://github.com/ryan5500/mynumbercard_statistics/runs/2791406837?check_suite_focus=true
  * 追加された以下3つのstepの合計時間が4分22秒だった。
    * Start local registry: 25秒
    * Build Image when docker image cache not hit: 2分49秒
    * Push Image to local registry when docker image cache not hit: 1分8秒


# レビュー上の注意点

## CIの中のみdocker-compose.ymlを上書き

* local registryを使う場合、docker-compose.ymlにimageを設定する必要がある。
  * docker-composeは、docker-compose.override.ymlがあればその内容は自動的に読まれ、docker-compose.ymlを上書きする。
    * https://docs.docker.com/compose/extends/
  * この仕組みを利用し、CIの中でのみdocker-compose.override.ymlがある状態にした。
    * CIでdocker-compose.override.ci.ymlをdocker-compose.override.ymlにリネームする。


## repository_dispatchイベントで起動されるreconvertワークフローにはキャッシュは未対応

repository_dispatchイベントによって起動されるreconvert workflowについては、actions/cache@v1アクションがrepository_dispatchイベントには対応していないため、同様の処理の追加を見送った。

以下のようなエラーメッセージが表示される。
* https://github.com/ryan5500/mynumbercard_statistics/runs/2793493159 のRun action/cache@v1 のログより抜粋

```
Warning: Event Validation Error: The event type repository_dispatch is not supported. Only push, pull_request events are supported at this time.
```